### PR TITLE
Update to swift 5.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -75,11 +75,11 @@
       },
       {
         "package": "TestSpy",
-        "repositoryURL": "https://github.com/dhardiman/TestSpy",
+        "repositoryURL": "https://github.com/f-meloni/TestSpy",
         "state": {
-          "branch": "master",
-          "revision": "16dd8492725ec5c1c1842857b0b28641befbcd8d",
-          "version": null
+          "branch": null,
+          "revision": "c6df56a8a6d2cc58175f9214588fdeacd3d7cfee",
+          "version": "0.4.0"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/Quick/Nimble",
         "state": {
           "branch": null,
-          "revision": "9a281b1cfa1c53d1e8bd92e1798e4e473af8d263",
-          "version": "7.3.3"
+          "revision": "43304bf2b1579fd555f2fdd51742771c1e4f2b98",
+          "version": "8.0.1"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/Quick/Quick",
         "state": {
           "branch": null,
-          "revision": "f2b5a06440ea87eba1a167cab37bf6496646c52e",
-          "version": "1.3.4"
+          "revision": "94df9b449508344667e5afc7e80f8bcbff1e4c37",
+          "version": "2.1.0"
         }
       },
       {
@@ -75,10 +75,10 @@
       },
       {
         "package": "TestSpy",
-        "repositoryURL": "https://github.com/f-meloni/TestSpy",
+        "repositoryURL": "https://github.com/dhardiman/TestSpy",
         "state": {
           "branch": "master",
-          "revision": "e0f1e9d4d10080762bb3b5256a94f347e74416f0",
+          "revision": "16dd8492725ec5c1c1842857b0b28641befbcd8d",
           "version": null
         }
       }

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .package(url: "https://github.com/f-meloni/SwiftGherkin", .branch("gherkin_indentation")),
         .package(url: "https://github.com/stencilproject/Stencil", from: "0.12.1"),
         .package(url: "https://github.com/Quick/Nimble", from: "8.0.0"),
-        .package(url: "https://github.com/dhardiman/TestSpy", .branch("master")),
+        .package(url: "https://github.com/f-meloni/TestSpy", from: "0.4.0"),
         .package(url: "https://github.com/apple/swift-package-manager.git", from: "0.1.0")
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -13,8 +13,8 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/f-meloni/SwiftGherkin", .branch("gherkin_indentation")),
         .package(url: "https://github.com/stencilproject/Stencil", from: "0.12.1"),
-        .package(url: "https://github.com/Quick/Nimble", from: "7.2.0"),
-        .package(url: "https://github.com/f-meloni/TestSpy", .branch("master")),
+        .package(url: "https://github.com/Quick/Nimble", from: "8.0.0"),
+        .package(url: "https://github.com/dhardiman/TestSpy", .branch("master")),
         .package(url: "https://github.com/apple/swift-package-manager.git", from: "0.1.0")
     ],
     targets: [
@@ -27,5 +27,6 @@ let package = Package(
         .testTarget(
             name: "CapriccioLibTests",
             dependencies: ["CapriccioLib", "Nimble", "TestSpy"])
-    ]
+    ],
+    swiftLanguageVersions: [.v5]
 )

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Capriccio
-![Swift 4.2](https://img.shields.io/badge/Swift-4.2-blue.svg)
+![Swift 5.0](https://img.shields.io/badge/Swift-5.0-blue.svg)
 [![Build Status](https://app.bitrise.io/app/ac2572c809b906b7/status.svg?token=or92GFZDMVH_iZxnvEHyfw&branch=master)](https://app.bitrise.io/app/ac2572c809b906b7)
 [![codecov](https://codecov.io/gh/f-meloni/capriccio/branch/master/graph/badge.svg)](https://codecov.io/gh/f-meloni/capriccio)
 


### PR DESCRIPTION
As mentioned for https://github.com/f-meloni/TestSpy/pull/1, we get dependency resolution issues when this is used in an SPM project where other dependencies have moved nimble on to 8.0.