### PR TITLE
Add support to folders

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -83,12 +83,21 @@
         }
       },
       {
+        "package": "llbuild",
+        "repositoryURL": "https://github.com/apple/swift-llbuild.git",
+        "state": {
+          "branch": null,
+          "revision": "f1c9ad9a253cdf1aa89a7f5c99c30b4513b06ddb",
+          "version": "0.1.1"
+        }
+      },
+      {
         "package": "SwiftPM",
         "repositoryURL": "https://github.com/apple/swift-package-manager.git",
         "state": {
           "branch": null,
-          "revision": "235aacc514cb81a6881364b0fedcb3dd083228f3",
-          "version": "0.3.0"
+          "revision": "8656a25cb906c1896339f950ac960ee1b4fe8034",
+          "version": "0.4.0"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -96,7 +96,7 @@
         "repositoryURL": "https://github.com/FelipeDocil/SwiftGherkin",
         "state": {
           "branch": "support_comments",
-          "revision": "6e7a6010f4c8ca77b6acd82bc0f42ea3d3efdbab",
+          "revision": "2cd9d17ffd520370b5591e724e70098f7a21f2dc",
           "version": null
         }
       },

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/Quick/Nimble",
         "state": {
           "branch": null,
-          "revision": "43304bf2b1579fd555f2fdd51742771c1e4f2b98",
-          "version": "8.0.1"
+          "revision": "f8657642dfdec9973efc79cc68bcef43a653a2bc",
+          "version": "8.0.2"
         }
       },
       {
@@ -69,7 +69,7 @@
         "repositoryURL": "https://github.com/FelipeDocil/SwiftGherkin",
         "state": {
           "branch": "support_comments",
-          "revision": "6e7a6010f4c8ca77b6acd82bc0f42ea3d3efdbab",
+          "revision": "2cd9d17ffd520370b5591e724e70098f7a21f2dc",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -12,11 +12,11 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/FelipeDocil/SwiftGherkin", .branch("support_comments")),
-        .package(url: "https://github.com/stencilproject/Stencil", from: "0.12.1"),
-        .package(url: "https://github.com/apple/swift-package-manager.git", from: "0.1.0"),
-        .package(url: "https://github.com/jpsim/Yams.git", from: "2.0.0"),
-        .package(url: "https://github.com/Quick/Nimble", from: "8.0.0"), // dev
-        .package(url: "https://github.com/f-meloni/TestSpy", from: "0.4.0"), // dev
+        .package(url: "https://github.com/stencilproject/Stencil", .exact("0.13.1")),
+        .package(url: "https://github.com/apple/swift-package-manager.git", .exact("0.3.0")),
+        .package(url: "https://github.com/jpsim/Yams.git", .exact("2.0.0")),
+        .package(url: "https://github.com/Quick/Nimble", .exact("8.0.2")), // dev
+        .package(url: "https://github.com/f-meloni/TestSpy", .exact("0.4.0")), // dev
         .package(url: "https://github.com/shibapm/Rocket", from: "0.9.0") // dev
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -12,11 +12,11 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/FelipeDocil/SwiftGherkin", .branch("support_comments")),
-        .package(url: "https://github.com/stencilproject/Stencil", from: "0.12.1"),
-        .package(url: "https://github.com/apple/swift-package-manager.git", from: "0.1.0"),
-        .package(url: "https://github.com/jpsim/Yams.git", from: "2.0.0"),
-        .package(url: "https://github.com/Quick/Nimble", from: "8.0.0"),
-        .package(url: "https://github.com/f-meloni/TestSpy", from: "0.4.0")
+        .package(url: "https://github.com/stencilproject/Stencil", .exact("0.13.1")),
+        .package(url: "https://github.com/apple/swift-package-manager.git", .exact("0.3.0")),
+        .package(url: "https://github.com/jpsim/Yams.git", .exact("2.0.0")),
+        .package(url: "https://github.com/Quick/Nimble", .exact("8.0.2")),
+        .package(url: "https://github.com/f-meloni/TestSpy", .exact("0.4.0"))
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/FelipeDocil/SwiftGherkin", .branch("support_comments")),
         .package(url: "https://github.com/stencilproject/Stencil", .exact("0.13.1")),
-        .package(url: "https://github.com/apple/swift-package-manager.git", .exact("0.3.0")),
+        .package(url: "https://github.com/apple/swift-package-manager.git", .exact("0.4.0")),
         .package(url: "https://github.com/jpsim/Yams.git", .exact("2.0.0")),
         .package(url: "https://github.com/Quick/Nimble", .exact("8.0.2")), // dev
         .package(url: "https://github.com/f-meloni/TestSpy", .exact("0.4.0")), // dev
@@ -25,7 +25,7 @@ let package = Package(
             dependencies: ["Gherkin", "Stencil"]),
         .target(
             name: "Capriccio",
-            dependencies: ["CapriccioLib", "Utility", "Yams"]),
+            dependencies: ["CapriccioLib", "SwiftPM", "Yams"]),
         .testTarget(
             name: "CapriccioLibTests",
             dependencies: ["CapriccioLib", "Nimble", "TestSpy"])

--- a/Sources/Capriccio/CapriccioArgumentsParser.swift
+++ b/Sources/Capriccio/CapriccioArgumentsParser.swift
@@ -5,7 +5,7 @@
 //  Created by Franco on 05/09/2018.
 //
 import Foundation
-import Utility
+import SPMUtility
 import Yams
 
 final class CapriccioArgumentsParser {

--- a/Sources/Capriccio/main.swift
+++ b/Sources/Capriccio/main.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import Utility
+import SPMUtility
 import CapriccioLib
 
 let capriccioVersion = "1.0.0"

--- a/Sources/Capriccio/main.swift
+++ b/Sources/Capriccio/main.swift
@@ -26,7 +26,7 @@ let destination = arguments.destination
 let featureFiles = filesFetcher.featureFiles(atPath: source)
 
 let filesReader = FeatureFilesReader()
-let features = filesReader.readFiles(atPaths: featureFiles, includedTags: arguments.includedTags, excludedTags: arguments.excludedTags)
+let features = filesReader.readFiles(sourcePath: source, atPaths: featureFiles, includedTags: arguments.includedTags, excludedTags: arguments.excludedTags)
 
 let filesWriter = SwiftTestsFilesWriter()
 filesWriter.writeSwiftTest(fromFeatures: features, inFolder: destination, generatedClassType: arguments.generatedClassType, disableSwiftLint: arguments.disableSwiftLint, templateFilePath: arguments.templateFilePath, useSingleFile: arguments.useSingleFile, version: capriccioVersion)

--- a/Sources/CapriccioLib/FeatureFilesFetcher.swift
+++ b/Sources/CapriccioLib/FeatureFilesFetcher.swift
@@ -18,12 +18,12 @@ public final class FeatureFilesFetcher {
         let directoryContents: [String]
         
         do {
-            directoryContents = try fileManager.contentsOfDirectory(atPath: path)
+            directoryContents = try fileManager.subpathsOfDirectory(atPath: path)
         } catch {
             fatalError("Unable to get files list at path \(path)")
         }
         
-        return directoryContents.filter { $0.hasSuffix(".feature") }.map { path + "/" + $0 }
+        return directoryContents.filter { $0.hasSuffix(".feature") }
     }
     
     public func yamlFile() -> String? {

--- a/Sources/CapriccioLib/FeatureFilesReader.swift
+++ b/Sources/CapriccioLib/FeatureFilesReader.swift
@@ -8,34 +8,46 @@
 import Foundation
 import Gherkin
 
+public struct Metadata {
+    let fileName: String
+    let path: String
+    let feature: Feature
+}
+
 public final class FeatureFilesReader {
     public init() { }
     
-    public func readFiles(atPaths paths: [String], includedTags: [String]?, excludedTags: [String]?) -> [Feature] {
-        let fileNames = paths.compactMap(getFileName)
-        let filesContent = paths.compactMap { try? String(contentsOfFile: $0).trimmingCharacters(in: CharacterSet.whitespacesAndNewlines) }
+    public func readFiles(sourcePath: String, atPaths paths: [String], includedTags: [String]?, excludedTags: [String]?) -> [Metadata] {
+        let metadata = paths.map(fileMetadata)
         
-        let newText: [String] = trimLines(from: filesContent)
-        let gherkinFeatures = newText.compactMap { try? Gherkin.Feature($0) }
-        var features = gherkinFeatures.compactMap(Feature.init)
+        let filesContent = paths.compactMap { try? String(contentsOfFile: sourcePath + "/" + $0).trimmingCharacters(in: CharacterSet.whitespacesAndNewlines) }
+        let texts: [String] = trimLines(from: filesContent)
         
-        for i in 0..<fileNames.count {
-            features[i] = features[i].withFileName(fileNames[i])
+        let textAndMetadata = zip(texts, metadata)
+        let metadatas = textAndMetadata.compactMap { (text, metadata) -> Metadata? in
+            guard let gherkinFeature = try? Gherkin.Feature(text) else {
+                print("Unable to parse the file: \(metadata.name) at \(metadata.path)")
+                return nil
+            }
+            
+            let feature = Feature(gherkinFeature: gherkinFeature)
+            let metadata = Metadata(fileName: metadata.name, path: metadata.path, feature: feature)
+            return metadata
         }
         
         if includedTags != nil || excludedTags != nil {
             let includedTag = includedTags?.compactMap(Tag.init) ?? []
             let excludedTag = excludedTags?.compactMap(Tag.init) ?? []
             
-            return filterFeatures(features: features, includedTags: includedTag, excludedTags: excludedTag)
+            return filterFeatures(metadatas: metadatas, includedTags: includedTag, excludedTags: excludedTag)
         } else {
-            return features
+            return metadatas
         }
     }
     
-    private func filterFeatures(features: [Feature], includedTags: [Tag], excludedTags: [Tag]) -> [Feature] {
-        return features.compactMap { feature -> Feature? in
-            let scenarios = feature.scenarios.filter { scenario in
+    private func filterFeatures(metadatas: [Metadata], includedTags: [Tag], excludedTags: [Tag]) -> [Metadata] {
+        return metadatas.compactMap { metadata -> Metadata? in
+            let scenarios = metadata.feature.scenarios.filter { scenario in
                 let tags = scenario.tags
                 
                 let includedTagsCheck = includedTags.isEmpty || tags.contains(where: includedTags.contains)
@@ -44,11 +56,16 @@ public final class FeatureFilesReader {
                 return includedTagsCheck && excludedTagsCheck
             }
             
-            return scenarios.count == 0 ?  nil : Feature(fileName: feature.fileName,
-                                                         description: feature.description,
-                                                         name: feature.name,
-                                                         scenarios: scenarios,
-                                                         tags: feature.tags)
+            guard scenarios.count != 0 else {
+                return nil
+            }
+            
+            let feature = Feature(description: metadata.feature.description,
+                                  name: metadata.feature.name,
+                                  scenarios: scenarios,
+                                  tags: metadata.feature.tags)
+            
+            return Metadata(fileName: metadata.fileName, path: metadata.path, feature: feature)
         }
     }
     
@@ -67,16 +84,21 @@ public final class FeatureFilesReader {
         }
     }
     
-    private func getFileName(from path: String) -> String? {
-        if let regex = try? NSRegularExpression(pattern: "\\s?/[\\w\\s]*\\.feature", options: .caseInsensitive)
-        {
-            let string = path as NSString
-            let fileName = regex.matches(in: path, options: [], range: NSRange(location: 0, length: string.length)).map {
-                string.substring(with: $0.range).replacingOccurrences(of: ".feature", with: "").replacingOccurrences(of: "/", with: "").validEntityName()
-            }
-            
-            return fileName.first
+    private func fileMetadata(from path: String) -> (name: String, path: String) {
+        let pathName = path.replacingOccurrences(of: ".feature", with: "").replacingOccurrences(of: "/", with: " ")
+        let outputPath = path.components(separatedBy: "/").dropLast().joined(separator: "/") + "/"
+        
+        let words = pathName.split(separator: " ")
+        let filteredWords = Array(NSOrderedSet(array: words)) as? [String.SubSequence]
+        
+        let name = filteredWords?.compactMap { word in
+            return word.prefix(1).uppercased() + word.dropFirst()
+            }.joined(separator: "_")
+        
+        guard let fileName = name else {
+            return (name: words.joined(separator: "_"), path: outputPath)
         }
-        return nil
+        
+        return (name: fileName, path: outputPath)
     }
 }

--- a/Sources/CapriccioLib/FeatureFilesReader.swift
+++ b/Sources/CapriccioLib/FeatureFilesReader.swift
@@ -91,7 +91,7 @@ public final class FeatureFilesReader {
         let words = pathName.split(separator: " ")
         let filteredWords = Array(NSOrderedSet(array: words)) as? [String.SubSequence]
         
-        let name = filteredWords?.compactMap { word in
+        let name = filteredWords?.map { word in
             return word.prefix(1).uppercased() + word.dropFirst()
             }.joined(separator: "_")
         

--- a/Sources/CapriccioLib/FileManaging.swift
+++ b/Sources/CapriccioLib/FileManaging.swift
@@ -9,8 +9,7 @@ import Foundation
 
 public protocol FileManaging {
     func contentsOfDirectory(atPath path: String) throws -> [String]
+    func subpathsOfDirectory(atPath: String) throws -> [String]
 }
 
 extension FileManager: FileManaging {}
-
-

--- a/Sources/CapriccioLib/Gherkin+SwiftCode.swift
+++ b/Sources/CapriccioLib/Gherkin+SwiftCode.swift
@@ -8,14 +8,12 @@
 import Gherkin
 
 /**
- fileName: File name where the feature came from
  description: Following text after `Feature:`
  name: description but without space and uppercased
  scenarios: List of Scenario
  tags: list of tags on that Feature
  */
 public struct Feature: Encodable, Equatable {
-    var fileName: String?
     var description: String
     var name: String
     var scenarios: [Scenario]
@@ -28,20 +26,11 @@ public struct Feature: Encodable, Equatable {
         tags = gherkinFeature.tags?.compactMap(Tag.init) ?? []
     }
     
-    init(fileName: String?, description: String, name: String, scenarios: [Scenario], tags: [Tag]) {
-        self.fileName = fileName
+    init(description: String, name: String, scenarios: [Scenario], tags: [Tag]) {
         self.description = description
         self.name = name
         self.scenarios = scenarios
         self.tags = tags
-    }
-    
-    func withFileName(_ fileName: String) -> Feature {
-        return Feature(fileName: fileName,
-                       description: description,
-                       name: name,
-                       scenarios: scenarios,
-                       tags: tags)
     }
 }
 

--- a/Sources/CapriccioLib/String+CamelCased.swift
+++ b/Sources/CapriccioLib/String+CamelCased.swift
@@ -30,7 +30,7 @@ extension String {
     var upperCamelCased: String {
         let words = split(separator: " ")
         return words.map { word in
-            return word.capitalized
+            return word.prefix(1).uppercased() + word.dropFirst()
         }.joined()
     }
 }

--- a/Sources/CapriccioLib/SwiftTestsFilesWriter.swift
+++ b/Sources/CapriccioLib/SwiftTestsFilesWriter.swift
@@ -20,15 +20,15 @@ public final class SwiftTestsFilesWriter {
         self.codeWriter = codeWriter
     }
     
-    public func writeSwiftTest(fromFeatures features: [Metadata], inFolder folderPath: String, generatedClassType: String?, disableSwiftLint: Bool, templateFilePath: String?, useSingleFile: Bool, version: String) {
+    public func writeSwiftTest(fromFeatures metadatas: [Metadata], inFolder folderPath: String, generatedClassType: String?, disableSwiftLint: Bool, templateFilePath: String?, useSingleFile: Bool, version: String) {
         
-        let featuresCode = features.map { swiftCodeGenerator.generateSwiftTestCode(forFeature: $0.feature, generatedClassType: generatedClassType, templateFilePath: templateFilePath, disableSwiftLint: disableSwiftLint, version: version) }
+        let featuresCode = metadatas.map { swiftCodeGenerator.generateSwiftTestCode(forFeature: $0.feature, generatedClassType: generatedClassType, templateFilePath: templateFilePath, disableSwiftLint: disableSwiftLint, version: version) }
         
         if useSingleFile {
             writeSingleFile(fromFeaturesCode: featuresCode, folderPath: folderPath)
         }
         else {
-            writeFeatureFiles(fromFeaturesCode: featuresCode, metadatas: features, folderPath: folderPath)
+            writeFeatureFiles(fromFeaturesCode: featuresCode, metadatas: metadatas, folderPath: folderPath)
         }
     }
     
@@ -40,9 +40,8 @@ public final class SwiftTestsFilesWriter {
     }
     
     private func writeFeatureFiles(fromFeaturesCode featuresCode: [String], metadatas: [Metadata], folderPath: String) {
-        for i in 0..<metadatas.count {
-            let code = featuresCode[i]
-            let metadata = metadatas[i]
+        for (index, metadata) in metadatas.enumerated() {
+            let code = featuresCode[index]
             
             let fileName = metadata.fileName
             let output = metadata.path

--- a/Tests/CapriccioLibTests/FeatureFilesFetcherTests.swift
+++ b/Tests/CapriccioLibTests/FeatureFilesFetcherTests.swift
@@ -28,9 +28,9 @@ final class FeatureFilesFetcherTests: XCTestCase {
     
     func testItCallsTheFileManagerWithTheCorrectPath() {
         let testPath = "testPath"
-        mockFileManager.contentOfDirectoryResult = []
+        mockFileManager.subpathsOfDirectoryResult = []
         _ = featureFilesFetcher.featureFiles(atPath: testPath)
-        expect(self.mockFileManager).to(haveReceived(.contentsOfDirectory(path: testPath)))
+        expect(self.mockFileManager).to(haveReceived(.subpathsOfDirectory(path: testPath)))
     }
     
     func testItReturnsTheFoundYAMLFiles() {
@@ -45,9 +45,9 @@ final class FeatureFilesFetcherTests: XCTestCase {
         let featureFiles = ["file1.feature",
                             "file2.feature",
                             "file3.feature"]
-        mockFileManager.contentOfDirectoryResult = featureFiles
+        mockFileManager.subpathsOfDirectoryResult = featureFiles
         let result = featureFilesFetcher.featureFiles(atPath: testPath)
-        expect(result) == featureFiles.map { testPath + "/" + $0 }
+        expect(result) == featureFiles.map { $0 }
     }
     
     func testItFiltersOutTheNotFeatureFiles() {
@@ -57,8 +57,8 @@ final class FeatureFilesFetcherTests: XCTestCase {
                             "file3.feature"]
         var files = ["/file4.jpg"]
         files.append(contentsOf: featureFiles)
-        mockFileManager.contentOfDirectoryResult = files
+        mockFileManager.subpathsOfDirectoryResult = files
         let result = featureFilesFetcher.featureFiles(atPath: testPath)
-        expect(result) == featureFiles.map { testPath + "/" + $0 }
+        expect(result) == featureFiles.map { $0 }
     }
 }

--- a/Tests/CapriccioLibTests/MockFileManager.swift
+++ b/Tests/CapriccioLibTests/MockFileManager.swift
@@ -9,8 +9,10 @@ import TestSpy
 @testable import CapriccioLib
 
 final class MockFileManager: TestSpy, FileManaging {
+    
     enum Method: Equatable {
         case contentsOfDirectory(path: String)
+        case subpathsOfDirectory(path: String)
     }
     
     var callstack = CallstackContainer<Method>()
@@ -19,5 +21,11 @@ final class MockFileManager: TestSpy, FileManaging {
     func contentsOfDirectory(atPath path: String) throws -> [String] {
         callstack.record(.contentsOfDirectory(path: path))
         return contentOfDirectoryResult
+    }
+    
+    var subpathsOfDirectoryResult: [String]!
+    func subpathsOfDirectory(atPath path: String) throws -> [String] {
+        callstack.record(.subpathsOfDirectory(path: path))
+        return subpathsOfDirectoryResult
     }
 }

--- a/Tests/CapriccioLibTests/SwiftTestCodeGeneratorTests+MultipleScenarios.swift
+++ b/Tests/CapriccioLibTests/SwiftTestCodeGeneratorTests+MultipleScenarios.swift
@@ -127,13 +127,13 @@ extension SwiftTestCodeGeneratorTests {
                 stepDefiner.stepSomethingHappens()
             }
             
-            func testScenario_IWantAComplexTest_TestaAndSituationa() {
+            func testScenario_IWantAComplexTest_TestAAndSituationA() {
                 stepDefiner.stepImInASituation()
                 stepDefiner.stepSomethingHappens(a: "testA")
                 stepDefiner.stepJustHappened(b: "situationA")
             }
 
-            func testScenario_IWantAComplexTest_TestbAndSituationb() {
+            func testScenario_IWantAComplexTest_TestBAndSituationB() {
                 stepDefiner.stepImInASituation()
                 stepDefiner.stepSomethingHappens(a: "testB")
                 stepDefiner.stepJustHappened(b: "situationB")

--- a/Tests/CapriccioLibTests/SwiftTestsFilesWriterTests.swift
+++ b/Tests/CapriccioLibTests/SwiftTestsFilesWriterTests.swift
@@ -22,20 +22,20 @@ final class SwiftTestsFilesWriterTests: XCTestCase {
     
     let testContent = "Test Code"
     
-    var feature1: Feature {
-        return Feature(fileName: "FeatureOne",
-                       description: "Feature number one",
-                       name: "FeatureNumberOne",
-                       scenarios: [],
-                       tags: [])
+    var feature1: Metadata {
+        let feature = Feature(description: "Feature number one",
+                              name: "FeatureNumberOne",
+                              scenarios: [],
+                              tags: [])
+        return Metadata(fileName: "FeatureOne", path: "", feature: feature)
     }
     
-    var feature2: Feature {
-        return Feature(fileName: "FeatureTwo",
-                       description: "Feature number two",
-                       name: "FeatureNumberTwo",
-                       scenarios: [],
-                       tags: [])
+    var feature2: Metadata {
+        let feature = Feature(description: "Feature number two",
+                              name: "FeatureNumberTwo",
+                              scenarios: [],
+                              tags: [])
+        return Metadata(fileName: "FeatureTwo", path: "", feature: feature)
     }
     
     override func setUp() {
@@ -59,10 +59,9 @@ final class SwiftTestsFilesWriterTests: XCTestCase {
         
         swiftTestsFilesWriter.writeSwiftTest(fromFeatures: [feature1], inFolder: testFolder, generatedClassType: generatedClassType, disableSwiftLint: true, templateFilePath: nil, useSingleFile: false, version: "1.0.0")
         
-        let filePath = self.filePath(forFeature: feature1)
-        
+        let filePath = self.filePath(forName: feature1.fileName)
         generatedFilesPaths.append(filePath)
-        expect(self.stubbedSwiftTestCodeGenerating).to(haveReceived(.generateSwiftTestCode(forFeature: feature1, generatedClassType: generatedClassType, templateFilePath: nil, disableSwiftLint: true, version: "1.0.0")))
+        expect(self.stubbedSwiftTestCodeGenerating).to(haveReceived(.generateSwiftTestCode(forFeature: feature1.feature, generatedClassType: generatedClassType, templateFilePath: nil, disableSwiftLint: true, version: "1.0.0")))
     }
     
     func testItPassesTheTemplatePathToTheCodeGenerator() {
@@ -70,19 +69,19 @@ final class SwiftTestsFilesWriterTests: XCTestCase {
         
         swiftTestsFilesWriter.writeSwiftTest(fromFeatures: [feature1], inFolder: testFolder, generatedClassType: nil, disableSwiftLint: true, templateFilePath: templatePath, useSingleFile: false, version: "1.0.0")
         
-        let filePath = self.filePath(forFeature: feature1)
+        let filePath = self.filePath(forName: feature1.fileName)
         generatedFilesPaths.append(filePath)
         
-        expect(self.stubbedSwiftTestCodeGenerating).to(haveReceived(.generateSwiftTestCode(forFeature: feature1, generatedClassType: nil, templateFilePath: templatePath, disableSwiftLint: true, version: "1.0.0")))
+        expect(self.stubbedSwiftTestCodeGenerating).to(haveReceived(.generateSwiftTestCode(forFeature: feature1.feature, generatedClassType: nil, templateFilePath: templatePath, disableSwiftLint: true, version: "1.0.0")))
     }
     
     func testItWritesTheCorrectFileForAFeature() {
         swiftTestsFilesWriter.writeSwiftTest(fromFeatures: [feature1], inFolder: testFolder, generatedClassType: nil,  disableSwiftLint: true, templateFilePath: nil, useSingleFile: false, version: "1.0.0")
         
-        let filePath = self.filePath(forFeature: feature1)
+        let filePath = self.filePath(forName: feature1.fileName)
         generatedFilesPaths.append(filePath)
         
-        expect(self.stubbedSwiftTestCodeGenerating).to(haveReceived(.generateSwiftTestCode(forFeature: feature1, generatedClassType: nil, templateFilePath: nil, disableSwiftLint: true, version: "1.0.0")))
+        expect(self.stubbedSwiftTestCodeGenerating).to(haveReceived(.generateSwiftTestCode(forFeature: feature1.feature, generatedClassType: nil, templateFilePath: nil, disableSwiftLint: true, version: "1.0.0")))
         expect(FileManager.default.fileExists(atPath: filePath)) == true
         expect(try? String(contentsOfFile: filePath)) == testContent
     }
@@ -90,17 +89,17 @@ final class SwiftTestsFilesWriterTests: XCTestCase {
     func testItWritesTheCorrectFileForMultipleFeatures() {
         swiftTestsFilesWriter.writeSwiftTest(fromFeatures: [feature1, feature2], inFolder: testFolder, generatedClassType: nil, disableSwiftLint: true, templateFilePath: nil, useSingleFile: false, version: "1.0.0")
         
-        let filePath = self.filePath(forFeature: feature1)
+        let filePath = self.filePath(forName: feature1.fileName)
         generatedFilesPaths.append(filePath)
         
-        expect(self.stubbedSwiftTestCodeGenerating).to(haveReceived(.generateSwiftTestCode(forFeature: feature1, generatedClassType: nil, templateFilePath: nil, disableSwiftLint: true, version: "1.0.0")))
+        expect(self.stubbedSwiftTestCodeGenerating).to(haveReceived(.generateSwiftTestCode(forFeature: feature1.feature, generatedClassType: nil, templateFilePath: nil, disableSwiftLint: true, version: "1.0.0")))
         expect(FileManager.default.fileExists(atPath: filePath)) == true
         expect(try? String(contentsOfFile: filePath)) == testContent
         
-        let file2Path = self.filePath(forFeature: feature2)
+        let file2Path = self.filePath(forName: feature2.fileName)
         generatedFilesPaths.append(file2Path)
         
-        expect(self.stubbedSwiftTestCodeGenerating).to(haveReceived(.generateSwiftTestCode(forFeature: feature2, generatedClassType: nil, templateFilePath: nil, disableSwiftLint: true, version: "1.0.0")))
+        expect(self.stubbedSwiftTestCodeGenerating).to(haveReceived(.generateSwiftTestCode(forFeature: feature2.feature, generatedClassType: nil, templateFilePath: nil, disableSwiftLint: true, version: "1.0.0")))
         expect(FileManager.default.fileExists(atPath: file2Path)) == true
         expect(try? String(contentsOfFile: file2Path)) == testContent
     }
@@ -115,9 +114,8 @@ final class SwiftTestsFilesWriterTests: XCTestCase {
         expect(try? String(contentsOfFile: filePath)) == testContent + "\n\n" + testContent
     }
     
-    private func filePath(forFeature feature: CapriccioLib.Feature) -> String {
-        let fileName = feature.fileName ?? feature.name
-        return testFolder + "/" + fileName.validEntityName() + "UITests.generated.swift"
+    private func filePath(forName name: String) -> String {
+        return testFolder + name + "UITests.generated.swift"
     }
 }
 
@@ -134,7 +132,7 @@ extension SwiftTestsFilesWriterTests {
         let codeWriter = SpyCodeWriting()
         swiftTestsFilesWriter = SwiftTestsFilesWriter(swiftCodeGenerator: stubbedSwiftTestCodeGenerating, codeWriter: codeWriter)
         
-        let filePath = singleFile ? testFolder + "/FeaturesUITests.swift" : self.filePath(forFeature: feature1)
+        let filePath = singleFile ? testFolder + "/FeaturesUITests.swift" : self.filePath(forName: feature1.fileName)
         generatedFilesPaths.append(filePath)
         
         try? testContent.write(toFile: filePath, atomically: false, encoding: .utf8)
@@ -156,7 +154,7 @@ private class StubbedSwiftTestCodeGenerating: SwiftTestCodeGenerating, TestSpy  
     var callstack = CallstackContainer<Method>()
     
     func generateSwiftTestCode(forFeature feature: Feature, generatedClassType: String?, templateFilePath: String?, disableSwiftLint: Bool, version: String) -> String {
-        callstack.record(.generateSwiftTestCode(forFeature: feature, generatedClassType: generatedClassType, templateFilePath: templateFilePath, disableSwiftLint: disableSwiftLint, version: "1.0.0"))
+        callstack.record(.generateSwiftTestCode(forFeature: feature, generatedClassType: generatedClassType, templateFilePath: templateFilePath, disableSwiftLint: disableSwiftLint, version: version))
         return result
     }
 }
@@ -164,12 +162,17 @@ private class StubbedSwiftTestCodeGenerating: SwiftTestCodeGenerating, TestSpy  
 private class SpyCodeWriting: CodeWriting, TestSpy {
     enum Method: Equatable {
         case write(code: String, featureFilePath: String)
+        case writeAndCreate(code: String, toFile: String, toDirectory: String)
     }
     
     var callstack: CallstackContainer<Method> = CallstackContainer()
     
     func write(code: String, toFile featureFilePath: String) {
         callstack.record(.write(code: code, featureFilePath: featureFilePath))
+    }
+    
+    func writeAndCreate(code: String, toFile filePath: String, toDirectory directoryPath: String) {
+        callstack.record(.writeAndCreate(code: code, toFile: filePath, toDirectory: directoryPath))
     }
 }
 


### PR DESCRIPTION
After your comment on my previous PR about support folders, I decided to implement it :)

Some changes on this PR:
 - Look for .features file on every subpath on the source folder
 - The method `validEntityName` wasn't saving the original capitalised string (e.g. "testA" becomes "Testa") so I change to uppercase only the first letter of every word, that means "testA" becomes "TestA"
- Also I wasn't very happy before about `Features` having the `fileName` so I created a `Metadata` to contain to file name and path
- Added path so we can differentiate files from their subpath

- Updated all the dependencies :)

Hope it's not too much to review  