### PR TITLE
Support steps with multiple keys

### DIFF
--- a/Sources/CapriccioLib/Gherkin+SwiftCode.swift
+++ b/Sources/CapriccioLib/Gherkin+SwiftCode.swift
@@ -125,7 +125,7 @@ public struct Example: Encodable, Equatable {
         let sortedDictionary = values.sorted(by: {$0.0 < $1.0 })
         for (key, value) in sortedDictionary {
             if step.description.contains("<\(key)>") {
-                text = step.description.replacingOccurrences(of: "<\(key)>", with: value)
+                text = text.description.replacingOccurrences(of: "<\(key)>", with: value)
                 parameters.append(Parameter(key: key, value: value))
             }
         }


### PR DESCRIPTION
**Description**
Currently, capriccio script do not support multiple keys in the same step, as for example:

**Current behaviour**
`And The user goes to <page> page and clicks on <button> button`

The current behaviour of the script will replace both of them but the replaces will override previous ones.

`And The user goes to <page> page and clicks on LOGIN button`

**Expected behaviour**

Script should support as many keys as we want

**How was fixed**

The issue was that script was always replacing the key over the original step instead of the updated step.
With this single change, now the script supports having as many keys as we want over any step and allow us to reduce size of the tests.